### PR TITLE
Add link to orcharhino docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Install and maintain [Prosody](http://prosody.im/) from offical repo with Ansibl
 Per default, this role also installs munin-node to monitor Prosody.
 Tested with Molecule, Docker, Vagrant and TravisCI.
 
+[Deploying Prosody using orcharhino](https://docs.orcharhino.com/or/docs/sources/usage_guides/deploying_an_internal_application_guide.html)
+
 Requirements
 ------------
 


### PR DESCRIPTION
This PR adds a link to the [Deploying an internal application guide](https://docs.orcharhino.com/or/docs/sources/usage_guides/deploying_an_internal_application_guide.html) which uses prosody as an example for custom content and this Ansible role to configure hosts.